### PR TITLE
Feature implementation from commits 2c79438..7c582e2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,9 @@ This project adheres to the [Contributor Covenant 1.2.](https://www.contributor-
 
 ## Questions
 
-* We do our best to have an [up-to-date documentation](https://casbin.org/docs/en/overview)
-* [Stack Overflow](https://stackoverflow.com) is the best place to start if you have a question. Please use the [casbin tag](https://stackoverflow.com/tags/casbin/info) we are actively monitoring. We encourage you to use Stack Overflow specially for Modeling Access Control Problems, in order to build a shared knowledge base.
-* You can also join our [Gitter community](https://gitter.im/casbin/Lobby).
-
+- We do our best to have an [up-to-date documentation](https://casbin.org/docs/overview)
+- [Stack Overflow](https://stackoverflow.com) is the best place to start if you have a question. Please use the [casbin tag](https://stackoverflow.com/tags/casbin/info) we are actively monitoring. We encourage you to use Stack Overflow specially for Modeling Access Control Problems, in order to build a shared knowledge base.
+- You can also join our [Gitter community](https://gitter.im/casbin/Lobby).
 
 ## Reporting issues
 
@@ -26,7 +25,6 @@ What are the steps to reproduce the issue?
 In what environment did you encounter the issue?
 
 Feature requests can also be submitted as issues.
-
 
 ## Pull requests
 

--- a/enforcer.go
+++ b/enforcer.go
@@ -66,13 +66,12 @@ type EnforceContext struct {
 //
 // File:
 //
-// 	e := casbin.NewEnforcer("path/to/basic_model.conf", "path/to/basic_policy.csv")
+//	e := casbin.NewEnforcer("path/to/basic_model.conf", "path/to/basic_policy.csv")
 //
 // MySQL DB:
 //
-// 	a := mysqladapter.NewDBAdapter("mysql", "mysql_username:mysql_password@tcp(127.0.0.1:3306)/")
-// 	e := casbin.NewEnforcer("path/to/basic_model.conf", a)
-//
+//	a := mysqladapter.NewDBAdapter("mysql", "mysql_username:mysql_password@tcp(127.0.0.1:3306)/")
+//	e := casbin.NewEnforcer("path/to/basic_model.conf", a)
 func NewEnforcer(params ...interface{}) (*Enforcer, error) {
 	e := &Enforcer{logger: &log.DefaultLogger{}}
 
@@ -276,11 +275,13 @@ func (e *Enforcer) GetNamedRoleManager(ptype string) rbac.RoleManager {
 
 // SetRoleManager sets the current role manager.
 func (e *Enforcer) SetRoleManager(rm rbac.RoleManager) {
+	e.invalidateMatcherMap()
 	e.rmMap["g"] = rm
 }
 
 // SetNamedRoleManager sets the role manager for the named policy.
 func (e *Enforcer) SetNamedRoleManager(ptype string, rm rbac.RoleManager) {
+	e.invalidateMatcherMap()
 	e.rmMap[ptype] = rm
 }
 
@@ -291,6 +292,8 @@ func (e *Enforcer) SetEffector(eft effector.Effector) {
 
 // ClearPolicy clears all policy.
 func (e *Enforcer) ClearPolicy() {
+	e.invalidateMatcherMap()
+
 	if e.dispatcher != nil && e.autoNotifyDispatcher {
 		_ = e.dispatcher.ClearPolicy()
 		return
@@ -300,6 +303,8 @@ func (e *Enforcer) ClearPolicy() {
 
 // LoadPolicy reloads the policy from file/database.
 func (e *Enforcer) LoadPolicy() error {
+	e.invalidateMatcherMap()
+
 	needToRebuild := false
 	newModel := e.model.Copy()
 	newModel.ClearPolicy()
@@ -343,6 +348,8 @@ func (e *Enforcer) LoadPolicy() error {
 }
 
 func (e *Enforcer) loadFilteredPolicy(filter interface{}) error {
+	e.invalidateMatcherMap()
+
 	var filteredAdapter persist.FilteredAdapter
 
 	// Attempt to cast the Adapter as a FilteredAdapter

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/casbin/casbin/v2/persist/cache"
 )
@@ -25,7 +26,7 @@ import (
 // CachedEnforcer wraps Enforcer and provides decision cache
 type CachedEnforcer struct {
 	*Enforcer
-	expireTime  uint
+	expireTime  time.Duration
 	cache       cache.Cache
 	enableCache int32
 	locker      *sync.RWMutex
@@ -45,8 +46,7 @@ func NewCachedEnforcer(params ...interface{}) (*CachedEnforcer, error) {
 	}
 
 	e.enableCache = 1
-	cache := cache.DefaultCache(make(map[string]bool))
-	e.cache = &cache
+	e.cache, _ = cache.NewDefaultCache()
 	e.locker = new(sync.RWMutex)
 	return e, nil
 }
@@ -132,7 +132,7 @@ func (e *CachedEnforcer) getCachedResult(key string) (res bool, err error) {
 	return e.cache.Get(key)
 }
 
-func (e *CachedEnforcer) SetExpireTime(expireTime uint) {
+func (e *CachedEnforcer) SetExpireTime(expireTime time.Duration) {
 	e.expireTime = expireTime
 }
 

--- a/enforcer_cached.go
+++ b/enforcer_cached.go
@@ -147,6 +147,17 @@ func (e *CachedEnforcer) setCachedResult(key string, res bool, extra ...interfac
 }
 
 func (e *CachedEnforcer) getKey(params ...interface{}) (string, bool) {
+	return GetCacheKey(params...)
+}
+
+// InvalidateCache deletes all the existing cached decisions.
+func (e *CachedEnforcer) InvalidateCache() error {
+	e.locker.Lock()
+	defer e.locker.Unlock()
+	return e.cache.Clear()
+}
+
+func GetCacheKey(params ...interface{}) (string, bool) {
 	key := strings.Builder{}
 	for _, param := range params {
 		switch typedParam := param.(type) {
@@ -160,11 +171,4 @@ func (e *CachedEnforcer) getKey(params ...interface{}) (string, bool) {
 		key.WriteString("$$")
 	}
 	return key.String(), true
-}
-
-// InvalidateCache deletes all the existing cached decisions.
-func (e *CachedEnforcer) InvalidateCache() error {
-	e.locker.Lock()
-	defer e.locker.Unlock()
-	return e.cache.Clear()
 }

--- a/enforcer_cached_synced.go
+++ b/enforcer_cached_synced.go
@@ -102,7 +102,7 @@ func (e *SyncedCachedEnforcer) AddPolicies(rules [][]string) (bool, error) {
 	if ok, err := e.checkManyAndRemoveCache(rules); !ok {
 		return ok, err
 	}
-	return e.SyncedEnforcer.RemovePolicies(rules)
+	return e.SyncedEnforcer.AddPolicies(rules)
 }
 
 func (e *SyncedCachedEnforcer) RemovePolicy(params ...interface{}) (bool, error) {

--- a/enforcer_cached_synced.go
+++ b/enforcer_cached_synced.go
@@ -1,0 +1,180 @@
+// Copyright 2018 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package casbin
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/casbin/casbin/v2/persist/cache"
+)
+
+// SyncedCachedEnforcer wraps Enforcer and provides decision sync cache
+type SyncedCachedEnforcer struct {
+	*SyncedEnforcer
+	expireTime  time.Duration
+	cache       cache.Cache
+	enableCache int32
+	locker      *sync.RWMutex
+}
+
+// NewSyncedCachedEnforcer creates a sync cached enforcer via file or DB.
+func NewSyncedCachedEnforcer(params ...interface{}) (*SyncedCachedEnforcer, error) {
+	e := &SyncedCachedEnforcer{}
+	var err error
+	e.SyncedEnforcer, err = NewSyncedEnforcer(params...)
+	if err != nil {
+		return nil, err
+	}
+
+	e.enableCache = 1
+	e.cache, _ = cache.NewSyncCache()
+	e.locker = new(sync.RWMutex)
+	return e, nil
+}
+
+// EnableCache determines whether to enable cache on Enforce(). When enableCache is enabled, cached result (true | false) will be returned for previous decisions.
+func (e *SyncedCachedEnforcer) EnableCache(enableCache bool) {
+	var enabled int32
+	if enableCache {
+		enabled = 1
+	}
+	atomic.StoreInt32(&e.enableCache, enabled)
+}
+
+// Enforce decides whether a "subject" can access a "object" with the operation "action", input parameters are usually: (sub, obj, act).
+// if rvals is not string , ingore the cache
+func (e *SyncedCachedEnforcer) Enforce(rvals ...interface{}) (bool, error) {
+	if atomic.LoadInt32(&e.enableCache) == 0 {
+		return e.SyncedEnforcer.Enforce(rvals...)
+	}
+
+	key, ok := e.getKey(rvals...)
+	if !ok {
+		return e.SyncedEnforcer.Enforce(rvals...)
+	}
+
+	if res, err := e.getCachedResult(key); err == nil {
+		return res, nil
+	} else if err != cache.ErrNoSuchKey {
+		return res, err
+	}
+
+	res, err := e.SyncedEnforcer.Enforce(rvals...)
+	if err != nil {
+		return false, err
+	}
+
+	err = e.setCachedResult(key, res, e.expireTime)
+	return res, err
+}
+
+func (e *SyncedCachedEnforcer) LoadPolicy() error {
+	if atomic.LoadInt32(&e.enableCache) != 0 {
+		if err := e.cache.Clear(); err != nil {
+			return err
+		}
+	}
+	return e.SyncedEnforcer.LoadPolicy()
+}
+
+func (e *SyncedCachedEnforcer) AddPolicy(params ...interface{}) (bool, error) {
+	if ok, err := e.checkOneAndRemoveCache(params...); !ok {
+		return ok, err
+	}
+	return e.SyncedEnforcer.AddPolicy(params...)
+}
+
+func (e *SyncedCachedEnforcer) AddPolicies(rules [][]string) (bool, error) {
+	if ok, err := e.checkManyAndRemoveCache(rules); !ok {
+		return ok, err
+	}
+	return e.SyncedEnforcer.RemovePolicies(rules)
+}
+
+func (e *SyncedCachedEnforcer) RemovePolicy(params ...interface{}) (bool, error) {
+	if ok, err := e.checkOneAndRemoveCache(params...); !ok {
+		return ok, err
+	}
+	return e.SyncedEnforcer.RemovePolicy(params...)
+}
+
+func (e *SyncedCachedEnforcer) RemovePolicies(rules [][]string) (bool, error) {
+	if ok, err := e.checkManyAndRemoveCache(rules); !ok {
+		return ok, err
+	}
+	return e.SyncedEnforcer.RemovePolicies(rules)
+}
+
+func (e *SyncedCachedEnforcer) getCachedResult(key string) (res bool, err error) {
+	return e.cache.Get(key)
+}
+
+func (e *SyncedCachedEnforcer) SetExpireTime(expireTime time.Duration) {
+	e.locker.Lock()
+	defer e.locker.Unlock()
+	e.expireTime = expireTime
+}
+
+// SetCache need to be sync cache
+func (e *SyncedCachedEnforcer) SetCache(c cache.Cache) {
+	e.locker.Lock()
+	defer e.locker.Unlock()
+	e.cache = c
+}
+
+func (e *SyncedCachedEnforcer) setCachedResult(key string, res bool, extra ...interface{}) error {
+	return e.cache.Set(key, res, extra...)
+}
+
+func (e *SyncedCachedEnforcer) getKey(params ...interface{}) (string, bool) {
+	return GetCacheKey(params...)
+}
+
+// InvalidateCache deletes all the existing cached decisions.
+func (e *SyncedCachedEnforcer) InvalidateCache() error {
+	return e.cache.Clear()
+}
+
+func (e *SyncedCachedEnforcer) checkOneAndRemoveCache(params ...interface{}) (bool, error) {
+	if atomic.LoadInt32(&e.enableCache) != 0 {
+		key, ok := e.getKey(params...)
+		if ok {
+			if err := e.cache.Delete(key); err != nil && err != cache.ErrNoSuchKey {
+				return false, err
+			}
+		}
+	}
+	return true, nil
+}
+
+func (e *SyncedCachedEnforcer) checkManyAndRemoveCache(rules [][]string) (bool, error) {
+	if len(rules) != 0 {
+		if atomic.LoadInt32(&e.enableCache) != 0 {
+			irule := make([]interface{}, len(rules[0]))
+			for _, rule := range rules {
+				for i, param := range rule {
+					irule[i] = param
+				}
+				key, _ := e.getKey(irule...)
+				if err := e.cache.Delete(key); err != nil && err != cache.ErrNoSuchKey {
+					return false, err
+				}
+			}
+		}
+	}
+	return true, nil
+}

--- a/enforcer_cached_synced_test.go
+++ b/enforcer_cached_synced_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package casbin
+
+import (
+	"sync"
+	"testing"
+)
+
+func testSyncEnforceCache(t *testing.T, e *SyncedCachedEnforcer, sub string, obj interface{}, act string, res bool) {
+	t.Helper()
+	if myRes, _ := e.Enforce(sub, obj, act); myRes != res {
+		t.Errorf("%s, %v, %s: %t, supposed to be %t", sub, obj, act, myRes, res)
+	}
+}
+
+func TestSyncCache(t *testing.T) {
+	e, _ := NewSyncedCachedEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+	// The cache is enabled by default for NewCachedEnforcer.
+	g := sync.WaitGroup{}
+	goThread := 1000
+	g.Add(goThread)
+	for i := 0; i < goThread; i++ {
+		go func() {
+			_, _ = e.AddPolicy("alice", "data2", "read")
+			testSyncEnforceCache(t, e, "alice", "data2", "read", true)
+			g.Done()
+		}()
+	}
+	g.Wait()
+	_, _ = e.RemovePolicy("alice", "data2", "read")
+
+	testSyncEnforceCache(t, e, "alice", "data1", "read", true)
+	testSyncEnforceCache(t, e, "alice", "data1", "write", false)
+	testSyncEnforceCache(t, e, "alice", "data2", "read", false)
+	testSyncEnforceCache(t, e, "alice", "data2", "write", false)
+	// The cache is enabled, calling RemovePolicy, LoadPolicy or RemovePolicies will
+	// also operate cached items.
+	_, _ = e.RemovePolicy("alice", "data1", "read")
+
+	testSyncEnforceCache(t, e, "alice", "data1", "read", false)
+	testSyncEnforceCache(t, e, "alice", "data1", "write", false)
+	testSyncEnforceCache(t, e, "alice", "data2", "read", false)
+	testSyncEnforceCache(t, e, "alice", "data2", "write", false)
+
+	e, _ = NewSyncedCachedEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
+
+	testSyncEnforceCache(t, e, "alice", "data1", "read", true)
+	testSyncEnforceCache(t, e, "bob", "data2", "write", true)
+	testSyncEnforceCache(t, e, "alice", "data2", "read", true)
+	testSyncEnforceCache(t, e, "alice", "data2", "write", true)
+
+	_, _ = e.RemovePolicies([][]string{
+		{"alice", "data1", "read"},
+		{"bob", "data2", "write"},
+	})
+
+	testSyncEnforceCache(t, e, "alice", "data1", "read", false)
+	testSyncEnforceCache(t, e, "bob", "data2", "write", false)
+	testSyncEnforceCache(t, e, "alice", "data2", "read", true)
+	testSyncEnforceCache(t, e, "alice", "data2", "write", true)
+}

--- a/enforcer_distributed.go
+++ b/enforcer_distributed.go
@@ -29,6 +29,8 @@ func (e *DistributedEnforcer) SetDispatcher(dispatcher persist.Dispatcher) {
 // AddPoliciesSelf provides a method for dispatcher to add authorization rules to the current policy.
 // The function returns the rules affected and error.
 func (d *DistributedEnforcer) AddPoliciesSelf(shouldPersist func() bool, sec string, ptype string, rules [][]string) (affected [][]string, err error) {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
 		var noExistsPolicy [][]string
 		for _, rule := range rules {
@@ -59,6 +61,8 @@ func (d *DistributedEnforcer) AddPoliciesSelf(shouldPersist func() bool, sec str
 // RemovePoliciesSelf provides a method for dispatcher to remove a set of rules from current policy.
 // The function returns the rules affected and error.
 func (d *DistributedEnforcer) RemovePoliciesSelf(shouldPersist func() bool, sec string, ptype string, rules [][]string) (affected [][]string, err error) {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
 		if err := d.adapter.(persist.BatchAdapter).RemovePolicies(sec, ptype, rules); err != nil {
 			if err.Error() != notImplemented {
@@ -82,6 +86,8 @@ func (d *DistributedEnforcer) RemovePoliciesSelf(shouldPersist func() bool, sec 
 // RemoveFilteredPolicySelf provides a method for dispatcher to remove an authorization rule from the current policy, field filters can be specified.
 // The function returns the rules affected and error.
 func (d *DistributedEnforcer) RemoveFilteredPolicySelf(shouldPersist func() bool, sec string, ptype string, fieldIndex int, fieldValues ...string) (affected [][]string, err error) {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
 		if err := d.adapter.RemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...); err != nil {
 			if err.Error() != notImplemented {
@@ -104,6 +110,8 @@ func (d *DistributedEnforcer) RemoveFilteredPolicySelf(shouldPersist func() bool
 
 // ClearPolicySelf provides a method for dispatcher to clear all rules from the current policy.
 func (d *DistributedEnforcer) ClearPolicySelf(shouldPersist func() bool) error {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
 		err := d.adapter.SavePolicy(nil)
 		if err != nil {
@@ -118,6 +126,8 @@ func (d *DistributedEnforcer) ClearPolicySelf(shouldPersist func() bool) error {
 
 // UpdatePolicySelf provides a method for dispatcher to update an authorization rule from the current policy.
 func (d *DistributedEnforcer) UpdatePolicySelf(shouldPersist func() bool, sec string, ptype string, oldRule, newRule []string) (affected bool, err error) {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
 		err := d.adapter.(persist.UpdatableAdapter).UpdatePolicy(sec, ptype, oldRule, newRule)
 		if err != nil {
@@ -146,6 +156,8 @@ func (d *DistributedEnforcer) UpdatePolicySelf(shouldPersist func() bool, sec st
 
 // UpdatePoliciesSelf provides a method for dispatcher to update a set of authorization rules from the current policy.
 func (d *DistributedEnforcer) UpdatePoliciesSelf(shouldPersist func() bool, sec string, ptype string, oldRules, newRules [][]string) (affected bool, err error) {
+	d.m.Lock()
+	defer d.m.Unlock()
 	if shouldPersist != nil && shouldPersist() {
 		err := d.adapter.(persist.UpdatableAdapter).UpdatePolicies(sec, ptype, oldRules, newRules)
 		if err != nil {
@@ -174,6 +186,8 @@ func (d *DistributedEnforcer) UpdatePoliciesSelf(shouldPersist func() bool, sec 
 
 // UpdateFilteredPoliciesSelf provides a method for dispatcher to update a set of authorization rules from the current policy.
 func (d *DistributedEnforcer) UpdateFilteredPoliciesSelf(shouldPersist func() bool, sec string, ptype string, newRules [][]string, fieldIndex int, fieldValues ...string) (bool, error) {
+	d.m.Lock()
+	defer d.m.Unlock()
 	var (
 		oldRules [][]string
 		err      error

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -140,6 +140,8 @@ type IEnforcer interface {
 
 	UpdateGroupingPolicy(oldRule []string, newRule []string) (bool, error)
 	UpdateGroupingPolicies(oldRules [][]string, newRules [][]string) (bool, error)
+	UpdateNamedGroupingPolicy(ptype string, oldRule []string, newRule []string) (bool, error)
+	UpdateNamedGroupingPolicies(ptype string, oldRules [][]string, newRules [][]string) (bool, error)
 
 	/* Management API with autoNotifyWatcher disabled */
 	SelfAddPolicy(sec string, ptype string, rule []string) (bool, error)

--- a/enforcer_interface.go
+++ b/enforcer_interface.go
@@ -110,6 +110,8 @@ type IEnforcer interface {
 	AddPolicies(rules [][]string) (bool, error)
 	AddNamedPolicy(ptype string, params ...interface{}) (bool, error)
 	AddNamedPolicies(ptype string, rules [][]string) (bool, error)
+	AddPoliciesEx(rules [][]string) (bool, error)
+	AddNamedPoliciesEx(ptype string, rules [][]string) (bool, error)
 	RemovePolicy(params ...interface{}) (bool, error)
 	RemovePolicies(rules [][]string) (bool, error)
 	RemoveFilteredPolicy(fieldIndex int, fieldValues ...string) (bool, error)
@@ -120,8 +122,10 @@ type IEnforcer interface {
 	HasNamedGroupingPolicy(ptype string, params ...interface{}) bool
 	AddGroupingPolicy(params ...interface{}) (bool, error)
 	AddGroupingPolicies(rules [][]string) (bool, error)
+	AddGroupingPoliciesEx(rules [][]string) (bool, error)
 	AddNamedGroupingPolicy(ptype string, params ...interface{}) (bool, error)
 	AddNamedGroupingPolicies(ptype string, rules [][]string) (bool, error)
+	AddNamedGroupingPoliciesEx(ptype string, rules [][]string) (bool, error)
 	RemoveGroupingPolicy(params ...interface{}) (bool, error)
 	RemoveGroupingPolicies(rules [][]string) (bool, error)
 	RemoveFilteredGroupingPolicy(fieldIndex int, fieldValues ...string) (bool, error)
@@ -140,6 +144,7 @@ type IEnforcer interface {
 	/* Management API with autoNotifyWatcher disabled */
 	SelfAddPolicy(sec string, ptype string, rule []string) (bool, error)
 	SelfAddPolicies(sec string, ptype string, rules [][]string) (bool, error)
+	SelfAddPoliciesEx(sec string, ptype string, rules [][]string) (bool, error)
 	SelfRemovePolicy(sec string, ptype string, rule []string) (bool, error)
 	SelfRemovePolicies(sec string, ptype string, rules [][]string) (bool, error)
 	SelfRemoveFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, error)

--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -376,6 +376,15 @@ func (e *SyncedEnforcer) AddPolicies(rules [][]string) (bool, error) {
 	return e.Enforcer.AddPolicies(rules)
 }
 
+// AddPoliciesEx adds authorization rules to the current policy.
+// If the rule already exists, the rule will not be added.
+// But unlike AddPolicies, other non-existent rules are added instead of returning false directly
+func (e *SyncedEnforcer) AddPoliciesEx(rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddPoliciesEx(rules)
+}
+
 // AddNamedPolicy adds an authorization rule to the current named policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
@@ -392,6 +401,15 @@ func (e *SyncedEnforcer) AddNamedPolicies(ptype string, rules [][]string) (bool,
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.AddNamedPolicies(ptype, rules)
+}
+
+// AddNamedPoliciesEx adds authorization rules to the current named policy.
+// If the rule already exists, the rule will not be added.
+// But unlike AddNamedPolicies, other non-existent rules are added instead of returning false directly
+func (e *SyncedEnforcer) AddNamedPoliciesEx(ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddNamedPoliciesEx(ptype, rules)
 }
 
 // RemovePolicy removes an authorization rule from the current policy.
@@ -506,6 +524,15 @@ func (e *SyncedEnforcer) AddGroupingPolicies(rules [][]string) (bool, error) {
 	return e.Enforcer.AddGroupingPolicies(rules)
 }
 
+// AddGroupingPoliciesEx adds role inheritance rules to the current policy.
+// If the rule already exists, the rule will not be added.
+// But unlike AddGroupingPolicies, other non-existent rules are added instead of returning false directly
+func (e *SyncedEnforcer) AddGroupingPoliciesEx(rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddGroupingPoliciesEx(rules)
+}
+
 // AddNamedGroupingPolicy adds a named role inheritance rule to the current policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
@@ -522,6 +549,15 @@ func (e *SyncedEnforcer) AddNamedGroupingPolicies(ptype string, rules [][]string
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.AddNamedGroupingPolicies(ptype, rules)
+}
+
+// AddNamedGroupingPoliciesEx adds named role inheritance rules to the current policy.
+// If the rule already exists, the rule will not be added.
+// But unlike AddNamedGroupingPolicies, other non-existent rules are added instead of returning false directly
+func (e *SyncedEnforcer) AddNamedGroupingPoliciesEx(ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.AddNamedGroupingPoliciesEx(ptype, rules)
 }
 
 // RemoveGroupingPolicy removes a role inheritance rule from the current policy.
@@ -607,6 +643,12 @@ func (e *SyncedEnforcer) SelfAddPolicies(sec string, ptype string, rules [][]str
 	e.m.Lock()
 	defer e.m.Unlock()
 	return e.Enforcer.SelfAddPolicies(sec, ptype, rules)
+}
+
+func (e *SyncedEnforcer) SelfAddPoliciesEx(sec string, ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.SelfAddPoliciesEx(sec, ptype, rules)
 }
 
 func (e *SyncedEnforcer) SelfRemovePolicy(sec string, ptype string, rule []string) (bool, error) {

--- a/enforcer_synced.go
+++ b/enforcer_synced.go
@@ -596,3 +596,45 @@ func (e *SyncedEnforcer) AddFunction(name string, function govaluate.ExpressionF
 	defer e.m.Unlock()
 	e.Enforcer.AddFunction(name, function)
 }
+
+func (e *SyncedEnforcer) SelfAddPolicy(sec string, ptype string, rule []string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.SelfAddPolicy(sec, ptype, rule)
+}
+
+func (e *SyncedEnforcer) SelfAddPolicies(sec string, ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.SelfAddPolicies(sec, ptype, rules)
+}
+
+func (e *SyncedEnforcer) SelfRemovePolicy(sec string, ptype string, rule []string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.SelfRemovePolicy(sec, ptype, rule)
+}
+
+func (e *SyncedEnforcer) SelfRemovePolicies(sec string, ptype string, rules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.SelfRemovePolicies(sec, ptype, rules)
+}
+
+func (e *SyncedEnforcer) SelfRemoveFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.SelfRemoveFilteredPolicy(sec, ptype, fieldIndex, fieldValues...)
+}
+
+func (e *SyncedEnforcer) SelfUpdatePolicy(sec string, ptype string, oldRule, newRule []string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.SelfUpdatePolicy(sec, ptype, oldRule, newRule)
+}
+
+func (e *SyncedEnforcer) SelfUpdatePolicies(sec string, ptype string, oldRules, newRules [][]string) (bool, error) {
+	e.m.Lock()
+	defer e.m.Unlock()
+	return e.Enforcer.SelfUpdatePolicies(sec, ptype, oldRules, newRules)
+}

--- a/enforcer_synced_test.go
+++ b/enforcer_synced_test.go
@@ -15,7 +15,9 @@
 package casbin
 
 import (
+	"github.com/casbin/casbin/v2/errors"
 	"github.com/casbin/casbin/v2/util"
+	"sort"
 	"testing"
 	"time"
 )
@@ -114,6 +116,43 @@ func TestSyncedEnforcerSelfAddPolicies(t *testing.T) {
 		}()
 		go func() {
 			_, _ = e.SelfAddPolicies("p", "p", [][]string{{"user5", "data5", "read"}, {"user6", "data6", "read"}})
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		testSyncedEnforcerGetPolicy(t, e, [][]string{
+			{"alice", "data1", "read"},
+			{"bob", "data2", "write"},
+			{"user1", "data1", "read"},
+			{"user2", "data2", "read"},
+			{"user3", "data3", "read"},
+			{"user4", "data4", "read"},
+			{"user5", "data5", "read"},
+			{"user6", "data6", "read"},
+		})
+	}
+}
+
+func TestSyncedEnforcerSelfAddPoliciesEx(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		e, _ := NewSyncedEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+		go func() {
+			_, _ = e.SelfAddPoliciesEx("p", "p", [][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}})
+		}()
+		go func() {
+			_, _ = e.SelfAddPoliciesEx("p", "p", [][]string{{"user2", "data2", "read"}, {"user3", "data3", "read"}})
+		}()
+		go func() {
+			_, _ = e.SelfAddPoliciesEx("p", "p", [][]string{{"user3", "data3", "read"}, {"user4", "data4", "read"}})
+		}()
+		go func() {
+			_, _ = e.SelfAddPoliciesEx("p", "p", [][]string{{"user4", "data4", "read"}, {"user5", "data5", "read"}})
+		}()
+		go func() {
+			_, _ = e.SelfAddPoliciesEx("p", "p", [][]string{{"user5", "data5", "read"}, {"user6", "data6", "read"}})
+		}()
+		go func() {
+			_, _ = e.SelfAddPoliciesEx("p", "p", [][]string{{"user6", "data6", "read"}, {"user1", "data1", "read"}})
 		}()
 
 		time.Sleep(100 * time.Millisecond)
@@ -357,5 +396,134 @@ func TestSyncedEnforcerSelfUpdatePolicies(t *testing.T) {
 			{"user5", "data5", "write"},
 			{"user6", "data6", "write"},
 		})
+	}
+}
+
+func TestSyncedEnforcerAddPoliciesEx(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		e, _ := NewSyncedEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+		go func() { _, _ = e.AddPoliciesEx([][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}}) }()
+		go func() { _, _ = e.AddPoliciesEx([][]string{{"user2", "data2", "read"}, {"user3", "data3", "read"}}) }()
+		go func() { _, _ = e.AddPoliciesEx([][]string{{"user4", "data4", "read"}, {"user5", "data5", "read"}}) }()
+		go func() { _, _ = e.AddPoliciesEx([][]string{{"user5", "data5", "read"}, {"user6", "data6", "read"}}) }()
+		go func() { _, _ = e.AddPoliciesEx([][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}}) }()
+		go func() { _, _ = e.AddPoliciesEx([][]string{{"user2", "data2", "read"}, {"user3", "data3", "read"}}) }()
+		go func() { _, _ = e.AddPoliciesEx([][]string{{"user4", "data4", "read"}, {"user5", "data5", "read"}}) }()
+		go func() { _, _ = e.AddPoliciesEx([][]string{{"user5", "data5", "read"}, {"user6", "data6", "read"}}) }()
+		time.Sleep(100 * time.Millisecond)
+
+		testSyncedEnforcerGetPolicy(t, e, [][]string{
+			{"alice", "data1", "read"},
+			{"bob", "data2", "write"},
+			{"user1", "data1", "read"},
+			{"user2", "data2", "read"},
+			{"user3", "data3", "read"},
+			{"user4", "data4", "read"},
+			{"user5", "data5", "read"},
+			{"user6", "data6", "read"},
+		})
+	}
+}
+
+func TestSyncedEnforcerAddNamedPoliciesEx(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		e, _ := NewSyncedEnforcer("examples/basic_model.conf", "examples/basic_policy.csv")
+		go func() {
+			_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}})
+		}()
+		go func() {
+			_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user2", "data2", "read"}, {"user3", "data3", "read"}})
+		}()
+		go func() {
+			_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user4", "data4", "read"}, {"user5", "data5", "read"}})
+		}()
+		go func() {
+			_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user5", "data5", "read"}, {"user6", "data6", "read"}})
+		}()
+		go func() {
+			_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}})
+		}()
+		go func() {
+			_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user2", "data2", "read"}, {"user3", "data3", "read"}})
+		}()
+		go func() {
+			_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user4", "data4", "read"}, {"user5", "data5", "read"}})
+		}()
+		go func() {
+			_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user5", "data5", "read"}, {"user6", "data6", "read"}})
+		}()
+		time.Sleep(100 * time.Millisecond)
+
+		testSyncedEnforcerGetPolicy(t, e, [][]string{
+			{"alice", "data1", "read"},
+			{"bob", "data2", "write"},
+			{"user1", "data1", "read"},
+			{"user2", "data2", "read"},
+			{"user3", "data3", "read"},
+			{"user4", "data4", "read"},
+			{"user5", "data5", "read"},
+			{"user6", "data6", "read"},
+		})
+	}
+}
+
+func testSyncedEnforcerGetUsers(t *testing.T, e *SyncedEnforcer, res []string, name string, domain ...string) {
+	t.Helper()
+	myRes, err := e.GetUsersForRole(name, domain...)
+	myResCopy := make([]string, len(myRes))
+	copy(myResCopy, myRes)
+	sort.Strings(myRes)
+	sort.Strings(res)
+	switch err {
+	case nil:
+		break
+	case errors.ERR_NAME_NOT_FOUND:
+		t.Log("No name found")
+	default:
+		t.Error("Users for ", name, " could not be fetched: ", err.Error())
+	}
+	t.Log("Users for ", name, ": ", myRes)
+
+	if !util.SetEquals(res, myRes) {
+		t.Error("Users for ", name, ": ", myRes, ", supposed to be ", res)
+	}
+}
+func TestSyncedEnforcerAddGroupingPoliciesEx(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		e, _ := NewSyncedEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
+		e.ClearPolicy()
+
+		go func() { _, _ = e.AddGroupingPoliciesEx([][]string{{"user1", "member"}, {"user2", "member"}}) }()
+		go func() { _, _ = e.AddGroupingPoliciesEx([][]string{{"user2", "member"}, {"user3", "member"}}) }()
+		go func() { _, _ = e.AddGroupingPoliciesEx([][]string{{"user4", "member"}, {"user5", "member"}}) }()
+		go func() { _, _ = e.AddGroupingPoliciesEx([][]string{{"user5", "member"}, {"user6", "member"}}) }()
+		go func() { _, _ = e.AddGroupingPoliciesEx([][]string{{"user1", "member"}, {"user2", "member"}}) }()
+		go func() { _, _ = e.AddGroupingPoliciesEx([][]string{{"user2", "member"}, {"user3", "member"}}) }()
+		go func() { _, _ = e.AddGroupingPoliciesEx([][]string{{"user4", "member"}, {"user5", "member"}}) }()
+		go func() { _, _ = e.AddGroupingPoliciesEx([][]string{{"user5", "member"}, {"user6", "member"}}) }()
+
+		time.Sleep(100 * time.Millisecond)
+
+		testSyncedEnforcerGetUsers(t, e, []string{"user1", "user2", "user3", "user4", "user5", "user6"}, "member")
+	}
+}
+
+func TestSyncedEnforcerAddNamedGroupingPoliciesEx(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		e, _ := NewSyncedEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
+		e.ClearPolicy()
+
+		go func() { _, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user1", "member"}, {"user2", "member"}}) }()
+		go func() { _, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user2", "member"}, {"user3", "member"}}) }()
+		go func() { _, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user4", "member"}, {"user5", "member"}}) }()
+		go func() { _, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user5", "member"}, {"user6", "member"}}) }()
+		go func() { _, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user1", "member"}, {"user2", "member"}}) }()
+		go func() { _, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user2", "member"}, {"user3", "member"}}) }()
+		go func() { _, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user4", "member"}, {"user5", "member"}}) }()
+		go func() { _, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user5", "member"}, {"user6", "member"}}) }()
+
+		time.Sleep(100 * time.Millisecond)
+
+		testSyncedEnforcerGetUsers(t, e, []string{"user1", "user2", "user3", "user4", "user5", "user6"}, "member")
 	}
 }

--- a/internal_api.go
+++ b/internal_api.go
@@ -64,13 +64,15 @@ func (e *Enforcer) addPolicyWithoutNotify(sec string, ptype string, rule []strin
 	return true, nil
 }
 
-// addPolicies adds rules to the current policy.
-func (e *Enforcer) addPoliciesWithoutNotify(sec string, ptype string, rules [][]string) (bool, error) {
+// addPoliciesWithoutNotify adds rules to the current policy without notify
+// If autoRemoveRepeat == true, existing rules are automatically filtered
+// Otherwise, false is returned directly
+func (e *Enforcer) addPoliciesWithoutNotify(sec string, ptype string, rules [][]string, autoRemoveRepeat bool) (bool, error) {
 	if e.dispatcher != nil && e.autoNotifyDispatcher {
 		return true, e.dispatcher.AddPolicies(sec, ptype, rules)
 	}
 
-	if e.model.HasPolicies(sec, ptype, rules) {
+	if !autoRemoveRepeat && e.model.HasPolicies(sec, ptype, rules) {
 		return false, nil
 	}
 
@@ -321,8 +323,10 @@ func (e *Enforcer) addPolicy(sec string, ptype string, rule []string) (bool, err
 }
 
 // addPolicies adds rules to the current policy.
-func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string) (bool, error) {
-	ok, err := e.addPoliciesWithoutNotify(sec, ptype, rules)
+// If autoRemoveRepeat == true, existing rules are automatically filtered
+// Otherwise, false is returned directly
+func (e *Enforcer) addPolicies(sec string, ptype string, rules [][]string, autoRemoveRepeat bool) (bool, error) {
+	ok, err := e.addPoliciesWithoutNotify(sec, ptype, rules, autoRemoveRepeat)
 	if !ok || err != nil {
 		return ok, err
 	}

--- a/management_api.go
+++ b/management_api.go
@@ -207,6 +207,13 @@ func (e *Enforcer) AddPolicies(rules [][]string) (bool, error) {
 	return e.AddNamedPolicies("p", rules)
 }
 
+// AddPoliciesEx adds authorization rules to the current policy.
+// If the rule already exists, the rule will not be added.
+// But unlike AddPolicies, other non-existent rules are added instead of returning false directly
+func (e *Enforcer) AddPoliciesEx(rules [][]string) (bool, error) {
+	return e.AddNamedPoliciesEx("p", rules)
+}
+
 // AddNamedPolicy adds an authorization rule to the current named policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
@@ -227,7 +234,14 @@ func (e *Enforcer) AddNamedPolicy(ptype string, params ...interface{}) (bool, er
 // If the rule already exists, the function returns false for the corresponding rule and the rule will not be added.
 // Otherwise the function returns true for the corresponding by adding the new rule.
 func (e *Enforcer) AddNamedPolicies(ptype string, rules [][]string) (bool, error) {
-	return e.addPolicies("p", ptype, rules)
+	return e.addPolicies("p", ptype, rules, false)
+}
+
+// AddNamedPoliciesEx adds authorization rules to the current named policy.
+// If the rule already exists, the rule will not be added.
+// But unlike AddNamedPolicies, other non-existent rules are added instead of returning false directly
+func (e *Enforcer) AddNamedPoliciesEx(ptype string, rules [][]string) (bool, error) {
+	return e.addPolicies("p", ptype, rules, true)
 }
 
 // RemovePolicy removes an authorization rule from the current policy.
@@ -327,6 +341,13 @@ func (e *Enforcer) AddGroupingPolicies(rules [][]string) (bool, error) {
 	return e.AddNamedGroupingPolicies("g", rules)
 }
 
+// AddGroupingPoliciesEx adds role inheritance rules to the current policy.
+// If the rule already exists, the rule will not be added.
+// But unlike AddGroupingPolicies, other non-existent rules are added instead of returning false directly
+func (e *Enforcer) AddGroupingPoliciesEx(rules [][]string) (bool, error) {
+	return e.AddNamedGroupingPoliciesEx("g", rules)
+}
+
 // AddNamedGroupingPolicy adds a named role inheritance rule to the current policy.
 // If the rule already exists, the function returns false and the rule will not be added.
 // Otherwise the function returns true by adding the new rule.
@@ -351,7 +372,14 @@ func (e *Enforcer) AddNamedGroupingPolicy(ptype string, params ...interface{}) (
 // If the rule already exists, the function returns false for the corresponding policy rule and the rule will not be added.
 // Otherwise the function returns true for the corresponding policy rule by adding the new rule.
 func (e *Enforcer) AddNamedGroupingPolicies(ptype string, rules [][]string) (bool, error) {
-	return e.addPolicies("g", ptype, rules)
+	return e.addPolicies("g", ptype, rules, false)
+}
+
+// AddNamedGroupingPoliciesEx adds named role inheritance rules to the current policy.
+// If the rule already exists, the rule will not be added.
+// But unlike AddNamedGroupingPolicies, other non-existent rules are added instead of returning false directly
+func (e *Enforcer) AddNamedGroupingPoliciesEx(ptype string, rules [][]string) (bool, error) {
+	return e.addPolicies("g", ptype, rules, true)
 }
 
 // RemoveGroupingPolicy removes a role inheritance rule from the current policy.
@@ -424,7 +452,11 @@ func (e *Enforcer) SelfAddPolicy(sec string, ptype string, rule []string) (bool,
 }
 
 func (e *Enforcer) SelfAddPolicies(sec string, ptype string, rules [][]string) (bool, error) {
-	return e.addPoliciesWithoutNotify(sec, ptype, rules)
+	return e.addPoliciesWithoutNotify(sec, ptype, rules, false)
+}
+
+func (e *Enforcer) SelfAddPoliciesEx(sec string, ptype string, rules [][]string) (bool, error) {
+	return e.addPoliciesWithoutNotify(sec, ptype, rules, true)
 }
 
 func (e *Enforcer) SelfRemovePolicy(sec string, ptype string, rule []string) (bool, error) {

--- a/management_api_test.go
+++ b/management_api_test.go
@@ -226,6 +226,19 @@ func TestModifyPolicyAPI(t *testing.T) {
 	_, _ = e.UpdatePolicies([][]string{{"eve", "data3", "write"}, {"leyo", "data4", "read"}, {"katy", "data4", "write"}},
 		[][]string{{"eve", "data3", "read"}, {"leyo", "data4", "write"}, {"katy", "data1", "write"}})
 	testGetPolicy(t, e, [][]string{{"eve", "data3", "read"}, {"jack", "data4", "read"}, {"katy", "data1", "write"}, {"leyo", "data4", "write"}, {"ham", "data4", "write"}})
+
+	e.ClearPolicy()
+	_, _ = e.AddPoliciesEx([][]string{{"user1", "data1", "read"}, {"user1", "data1", "read"}})
+	testGetPolicy(t, e, [][]string{{"user1", "data1", "read"}})
+	// {"user1", "data1", "read"} repeated
+	_, _ = e.AddPoliciesEx([][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}})
+	testGetPolicy(t, e, [][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}})
+	// {"user1", "data1", "read"}, {"user2", "data2", "read"} repeated
+	_, _ = e.AddNamedPoliciesEx("p", [][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}, {"user3", "data3", "read"}})
+	testGetPolicy(t, e, [][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}, {"user3", "data3", "read"}})
+	// {"user1", "data1", "read"}, {"user2", "data2", "read"}, , {"user3", "data3", "read"} repeated
+	_, _ = e.SelfAddPoliciesEx("p", "p", [][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}, {"user3", "data3", "read"}, {"user4", "data4", "read"}})
+	testGetPolicy(t, e, [][]string{{"user1", "data1", "read"}, {"user2", "data2", "read"}, {"user3", "data3", "read"}, {"user4", "data4", "read"}})
 }
 
 func TestModifyGroupingPolicyAPI(t *testing.T) {
@@ -300,4 +313,13 @@ func TestModifyGroupingPolicyAPI(t *testing.T) {
 	testGetRoles(t, e, []string{"data5_admin"}, "admin")
 	testGetRoles(t, e, []string{"admin_groups"}, "eve")
 
+	e.ClearPolicy()
+	_, _ = e.AddGroupingPoliciesEx([][]string{{"user1", "member"}})
+	testGetUsers(t, e, []string{"user1"}, "member")
+	// {"user1", "member"} repeated
+	_, _ = e.AddGroupingPoliciesEx([][]string{{"user1", "member"}, {"user2", "member"}})
+	testGetUsers(t, e, []string{"user1", "user2"}, "member")
+	// {"user1", "member"}, {"user2", "member"} repeated
+	_, _ = e.AddNamedGroupingPoliciesEx("g", [][]string{{"user1", "member"}, {"user2", "member"}, {"user3", "member"}})
+	testGetUsers(t, e, []string{"user1", "user2", "user3"}, "member")
 }

--- a/persist/cache/cache.go
+++ b/persist/cache/cache.go
@@ -20,7 +20,7 @@ var ErrNoSuchKey = errors.New("there's no such key existing in cache")
 
 type Cache interface {
 	// Set puts key and value into cache.
-	// First parameter for extra should be uint denoting expected survival time.
+	// First parameter for extra should be time.Time object denoting expected survival time.
 	// If survival time equals 0 or less, the key will always be survival.
 	Set(key string, value bool, extra ...interface{}) error
 

--- a/persist/cache/cache_sync.go
+++ b/persist/cache/cache_sync.go
@@ -1,0 +1,87 @@
+// Copyright 2021 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+type SyncCache struct {
+	cache DefaultCache
+	sync.RWMutex
+}
+
+func (c *SyncCache) Set(key string, value bool, extra ...interface{}) error {
+	ttl := time.Duration(-1)
+	if len(extra) > 0 {
+		ttl = extra[0].(time.Duration)
+	}
+	(*c).Lock()
+	defer (*c).Unlock()
+	(*c).cache[key] = cacheItem{
+		value:     value,
+		expiresAt: time.Now().Add(ttl),
+		ttl:       ttl,
+	}
+	return nil
+}
+
+func (c *SyncCache) Get(key string) (bool, error) {
+	(*c).RLock()
+	res, ok := (*c).cache[key]
+	(*c).RUnlock()
+	if !ok {
+		return false, ErrNoSuchKey
+	} else {
+		if res.ttl > 0 && time.Now().After(res.expiresAt) {
+			(*c).Lock()
+			defer (*c).Unlock()
+			delete((*c).cache, key)
+			return false, ErrNoSuchKey
+		}
+		return res.value, nil
+	}
+}
+
+func (c *SyncCache) Delete(key string) error {
+	(*c).RLock()
+	_, ok := (*c).cache[key]
+	(*c).RUnlock()
+	if !ok {
+		return ErrNoSuchKey
+	} else {
+		(*c).Lock()
+		defer (*c).Unlock()
+		delete((*c).cache, key)
+		return nil
+	}
+}
+
+func (c *SyncCache) Clear() error {
+	*c = SyncCache{
+		make(DefaultCache),
+		sync.RWMutex{},
+	}
+	return nil
+}
+
+func NewSyncCache() (Cache, error) {
+	cache := SyncCache{
+		make(DefaultCache),
+		sync.RWMutex{},
+	}
+	return &cache, nil
+}

--- a/persist/string-adapter/adapter.go
+++ b/persist/string-adapter/adapter.go
@@ -1,0 +1,92 @@
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stringadapter
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	"github.com/casbin/casbin/v2/model"
+	"github.com/casbin/casbin/v2/persist"
+	"github.com/casbin/casbin/v2/util"
+)
+
+// Adapter is the string adapter for Casbin.
+// It can load policy from string or save policy to string.
+type Adapter struct {
+	Line string
+}
+
+// NewAdapter is the constructor for Adapter.
+func NewAdapter(line string) *Adapter {
+	return &Adapter{
+		Line: line,
+	}
+}
+
+// LoadPolicy loads all policy rules from the storage.
+func (a *Adapter) LoadPolicy(model model.Model) error {
+	if a.Line == "" {
+		return errors.New("invalid line, line cannot be empty")
+	}
+	strs := strings.Split(a.Line, "\n")
+	for _, str := range strs {
+		if str == "" {
+			continue
+		}
+		_ = persist.LoadPolicyLine(str, model)
+	}
+
+	return nil
+}
+
+// SavePolicy saves all policy rules to the storage.
+func (a *Adapter) SavePolicy(model model.Model) error {
+	var tmp bytes.Buffer
+	for ptype, ast := range model["p"] {
+		for _, rule := range ast.Policy {
+			tmp.WriteString(ptype + ", ")
+			tmp.WriteString(util.ArrayToString(rule))
+			tmp.WriteString("\n")
+		}
+	}
+
+	for ptype, ast := range model["g"] {
+		for _, rule := range ast.Policy {
+			tmp.WriteString(ptype + ", ")
+			tmp.WriteString(util.ArrayToString(rule))
+			tmp.WriteString("\n")
+		}
+	}
+	a.Line = strings.TrimRight(tmp.String(), "\n")
+	return nil
+}
+
+// AddPolicy adds a policy rule to the storage.
+func (a *Adapter) AddPolicy(sec string, ptype string, rule []string) error {
+	return errors.New("not implemented")
+}
+
+// RemovePolicy removes a policy rule from the storage.
+func (a *Adapter) RemovePolicy(sec string, ptype string, rule []string) error {
+	a.Line = ""
+	return nil
+}
+
+// RemoveFilteredPolicy removes policy rules that match the filter from the storage.
+func (a *Adapter) RemoveFilteredPolicy(sec string, ptype string, fieldIndex int, fieldValues ...string) error {
+	return errors.New("not implemented")
+}

--- a/persist/string-adapter/adapter_test.go
+++ b/persist/string-adapter/adapter_test.go
@@ -1,0 +1,101 @@
+// Copyright 2017 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stringadapter
+
+import (
+	"testing"
+
+	"github.com/casbin/casbin/v2"
+	"github.com/casbin/casbin/v2/model"
+)
+
+func Test_KeyMatchRbac(t *testing.T) {
+	conf := `
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _ , _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub)  && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act)
+`
+	line := `
+p, alice, /alice_data/*, (GET)|(POST)
+p, alice, /alice_data/resource1, POST
+p, data_group_admin, /admin/*, POST
+p, data_group_admin, /bob_data/*, POST
+g, alice, data_group_admin
+`
+	a := NewAdapter(line)
+	m := model.NewModel()
+	err := m.LoadModelFromText(conf)
+	if err != nil {
+		t.Errorf("load model from text failed: %v", err.Error())
+		return
+	}
+	e, _ := casbin.NewEnforcer(m, a)
+	sub := "alice"
+	obj := "/alice_data/login"
+	act := "POST"
+	if res, _ := e.Enforce(sub, obj, act); !res {
+		t.Error("unexpected enforce result")
+	}
+}
+
+func Test_StringRbac(t *testing.T) {
+	conf := `
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _ , _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+`
+	line := `
+p, alice, data1, read
+p, data_group_admin, data3, read
+p, data_group_admin, data3, write
+g, alice, data_group_admin
+`
+	a := NewAdapter(line)
+	m := model.NewModel()
+	err := m.LoadModelFromText(conf)
+	if err != nil {
+		t.Errorf("load model from text failed: %v", err.Error())
+		return
+	}
+	e, _ := casbin.NewEnforcer(m, a)
+	sub := "alice" // the user that wants to access a resource.
+	obj := "data1" // the resource that is going to be accessed.
+	act := "read"  // the operation that the user performs on the resource.
+	if res, _ := e.Enforce(sub, obj, act); !res {
+		t.Error("unexpected enforce result")
+	}
+}

--- a/rbac_api_synced.go
+++ b/rbac_api_synced.go
@@ -160,8 +160,8 @@ func (e *SyncedEnforcer) GetImplicitRolesForUser(name string, domain ...string) 
 // GetPermissionsForUser("alice") can only get: [["alice", "data2", "read"]].
 // But GetImplicitPermissionsForUser("alice") will get: [["admin", "data1", "read"], ["alice", "data2", "read"]].
 func (e *SyncedEnforcer) GetImplicitPermissionsForUser(user string, domain ...string) ([][]string, error) {
-	e.m.RLock()
-	defer e.m.RUnlock()
+	e.m.Lock()
+	defer e.m.Unlock()
 	return e.Enforcer.GetImplicitPermissionsForUser(user, domain...)
 }
 

--- a/rbac_api_with_domains.go
+++ b/rbac_api_with_domains.go
@@ -144,3 +144,24 @@ func (e *Enforcer) DeleteDomains(domains ...string) (bool, error) {
 func (e *Enforcer) GetAllDomains() ([]string, error) {
 	return e.model["g"]["g"].RM.GetAllDomains()
 }
+
+// GetAllRolesByDomain would get all roles associated with the domain.
+// note: Not applicable to Domains with inheritance relationship  (implicit roles)
+func (e *Enforcer) GetAllRolesByDomain(domain string) []string {
+	g := e.model["g"]["g"]
+	policies := g.Policy
+	roles := make([]string, 0)
+	existMap := make(map[string]bool) // remove duplicates
+
+	for _, policy := range policies {
+		if policy[len(policy)-1] == domain {
+			role := policy[len(policy)-2]
+			if _, ok := existMap[role]; !ok {
+				roles = append(roles, role)
+				existMap[role] = true
+			}
+		}
+	}
+
+	return roles
+}

--- a/rbac_api_with_domains_test.go
+++ b/rbac_api_with_domains_test.go
@@ -267,3 +267,23 @@ func TestGetAllDomains(t *testing.T) {
 
 	testGetAllDomains(t, e, []string{"domain1", "domain2"})
 }
+
+func testGetAllRolesByDomain(t *testing.T, e *Enforcer, domain string, expected []string) {
+	if !util.SetEquals(e.GetAllRolesByDomain(domain), expected) {
+		t.Errorf("roles in %s: %v, supposed to be %v\n", domain, e.GetAllRolesByDomain(domain), expected)
+	}
+}
+
+func TestGetAllRolesByDomain(t *testing.T) {
+	e, _ := NewEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy.csv")
+
+	testGetAllRolesByDomain(t, e, "domain1", []string{"admin"})
+	testGetAllRolesByDomain(t, e, "domain2", []string{"admin"})
+
+	e, _ = NewEnforcer("examples/rbac_with_domains_model.conf", "examples/rbac_with_domains_policy2.csv")
+
+	testGetAllRolesByDomain(t, e, "domain1", []string{"admin"})
+	testGetAllRolesByDomain(t, e, "domain2", []string{"admin"})
+	testGetAllRolesByDomain(t, e, "domain3", []string{"user"})
+
+}

--- a/util/builtin_operators.go
+++ b/util/builtin_operators.go
@@ -272,15 +272,24 @@ func KeyMatch4Func(args ...interface{}) (interface{}, error) {
 	return bool(KeyMatch4(name1, name2)), nil
 }
 
-// KeyMatch determines whether key1 matches the pattern of key2 and ignores the parameters in key2.
-// For example, "/foo/bar?status=1&type=2" matches "/foo/bar"
+// KeyMatch5 determines whether key1 matches the pattern of key2 (similar to RESTful path), key2 can contain a *
+// For example, 
+// - "/foo/bar?status=1&type=2" matches "/foo/bar"
+// - "/parent/child1" and "/parent/child1" matches "/parent/*"
+// - "/parent/child1?status=1" matches "/parent/*"
 func KeyMatch5(key1 string, key2 string) bool {
 	i := strings.Index(key1, "?")
-	if i == -1 {
-		return key1 == key2
+
+	if i != -1 {
+		key1 = key1[:i]
 	}
 
-	return key1[:i] == key2
+	key2 = strings.Replace(key2, "/*", "/.*", -1)
+
+	re := regexp.MustCompile(`\{[^/]+\}`)
+	key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
+
+	return RegexMatch(key1, "^"+key2+"$")
 }
 
 // KeyMatch5Func is the wrapper for KeyMatch5.

--- a/util/builtin_operators_test.go
+++ b/util/builtin_operators_test.go
@@ -494,6 +494,35 @@ func TestKeyMatch5Func(t *testing.T) {
 	testKeyMatch5Func(t, false, "", "/parent/child/?status=1&type=2", "/parent/child")
 	testKeyMatch5Func(t, false, "", "/parent/child?status=1&type=2", "/parent/child/")
 
+	testKeyMatch5Func(t, true, "", "/foo", "/foo")
+	testKeyMatch5Func(t, true, "", "/foo", "/foo*")
+	testKeyMatch5Func(t, false, "", "/foo", "/foo/*")
+	testKeyMatch5Func(t, false, "", "/foo/bar", "/foo")
+	testKeyMatch5Func(t, false, "", "/foo/bar", "/foo*")
+	testKeyMatch5Func(t, true, "", "/foo/bar", "/foo/*")
+	testKeyMatch5Func(t, false, "", "/foobar", "/foo")
+	testKeyMatch5Func(t, false, "", "/foobar", "/foo*")
+	testKeyMatch5Func(t, false, "", "/foobar", "/foo/*")
+
+	testKeyMatch5Func(t, false, "", "/", "/{resource}")
+	testKeyMatch5Func(t, true, "", "/resource1", "/{resource}")
+	testKeyMatch5Func(t, false, "", "/myid", "/{id}/using/{resId}")
+	testKeyMatch5Func(t, true, "", "/myid/using/myresid", "/{id}/using/{resId}")
+
+	testKeyMatch5Func(t, false, "", "/proxy/myid", "/proxy/{id}/*")
+	testKeyMatch5Func(t, true, "", "/proxy/myid/", "/proxy/{id}/*")
+	testKeyMatch5Func(t, true, "", "/proxy/myid/res", "/proxy/{id}/*")
+	testKeyMatch5Func(t, true, "", "/proxy/myid/res/res2", "/proxy/{id}/*")
+	testKeyMatch5Func(t, true, "", "/proxy/myid/res/res2/res3", "/proxy/{id}/*")
+	testKeyMatch5Func(t, false, "", "/proxy/", "/proxy/{id}/*")
+
+	testKeyMatch5Func(t, false, "", "/proxy/myid?status=1&type=2", "/proxy/{id}/*")
+	testKeyMatch5Func(t, true, "", "/proxy/myid/", "/proxy/{id}/*")
+	testKeyMatch5Func(t, true, "", "/proxy/myid/res?status=1&type=2", "/proxy/{id}/*")
+	testKeyMatch5Func(t, true, "", "/proxy/myid/res/res2?status=1&type=2", "/proxy/{id}/*")
+	testKeyMatch5Func(t, true, "", "/proxy/myid/res/res2/res3?status=1&type=2", "/proxy/{id}/*")
+	testKeyMatch5Func(t, false, "", "/proxy/", "/proxy/{id}/*")
+
 }
 
 func TestIPMatchFunc(t *testing.T) {

--- a/util/util.go
+++ b/util/util.go
@@ -70,6 +70,44 @@ func Array2DEquals(a [][]string, b [][]string) bool {
 	return true
 }
 
+// SortArray2D  Sorts the two-dimensional string array
+func SortArray2D(arr [][]string) {
+	if len(arr) != 0 {
+		sort.Slice(arr, func(i, j int) bool {
+			elementLen := len(arr[0])
+			for k := 0; k < elementLen; k++ {
+				if arr[i][k] < arr[j][k] {
+					return true
+				} else if arr[i][k] > arr[j][k] {
+					return false
+				}
+			}
+			return true
+		})
+	}
+}
+
+// SortedArray2DEquals determines whether two 2-dimensional string arrays are identical.
+func SortedArray2DEquals(a [][]string, b [][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	copyA := make([][]string, len(a))
+	copy(copyA, a)
+	copyB := make([][]string, len(b))
+	copy(copyB, b)
+
+	SortArray2D(copyA)
+	SortArray2D(copyB)
+
+	for i, v := range copyA {
+		if !ArrayEquals(v, copyB[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // ArrayRemoveDuplicates removes any duplicated elements in a string array.
 func ArrayRemoveDuplicates(s *[]string) {
 	found := make(map[string]bool)

--- a/util/util.go
+++ b/util/util.go
@@ -323,8 +323,8 @@ func NewSyncLRUCache(capacity int) *SyncLRUCache {
 }
 
 func (cache *SyncLRUCache) Get(key interface{}) (value interface{}, ok bool) {
-	cache.rwm.RLock()
-	defer cache.rwm.RUnlock()
+	cache.rwm.Lock()
+	defer cache.rwm.Unlock()
 	return cache.LRUCache.Get(key)
 }
 


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `2c79438..7c582e2`
**Files Changed:** 23 (22 programming files)
**Programming Ratio:** 95.7%

**Commits included:**
- fix: fix AddPolicies()'s bug in SyncedCachedEnforcer (#1221)
- feat: add sync cache and synced cached enforcer (#1217)
- fix: Data race in GetImplicitPermissionsForUser (#1210)
- fix: add UpdateNamedGroupingPolicy() APIs to implement the IEnforcer interface (#1207)
- feat: make the default cache expirable (#1203)
- feat: merge string-adapter into casbin main library (#1201)
- feat: Add methods such as AddPoliciesEx (#1196)
- feat: fix locks in SyncedEnforcer Self* management API (#1195)
- fix: add support to use '*' in keymatch5 utils (#1177)
- feat: add GetAllRolesByDomain() API (#1190)
... and 5 more commits